### PR TITLE
Add scope validation middleware

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ keywords = ["actix", "http", "web", "cryptography"]
 license = "MIT"
 name = "actix-4-jwt-auth"
 repository = "https://github.com/spectare/actix-4-jwt-auth"
-version = "1.0.0"
+version = "1.1.0"
 
 [package.metadata.docs.rs]
 rustdoc-args = ["--cfg", "docsrs"]

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ In order to make use of this crate, you can add it to your Cargo.toml
 This crate is build with actix-4.
 
 ```
-actix-4-jwt-auth = "1.0.0"
+actix-4-jwt-auth = "1.1.0"
 ```
 
 Or when you like to use the latest as found on github:
@@ -48,9 +48,12 @@ You can wire your application like
           }
       };
 
+      let scope_validator = OidcScopeValidator(vec!["openid", "profile"]);
+
       HttpServer::new(move || {
         App::new()
                 .app_data(oidc.clone())
+                .wrap(scope_validator.clone())
                 .wrap(biscuit_validator.clone())
                 // .wrap(OidcBiscuitValidator::default()) //without issuer verification
                 .service(authenticated_user),

--- a/src/error.rs
+++ b/src/error.rs
@@ -42,6 +42,9 @@ pub enum OIDCValidationError {
     ///Token does not have sufficient rights
     #[error("Token does not have sufficient rights")]
     IvalidAccess,
+    ///Scopes in an access token are not valid
+    #[error("Scopes in an access token are not valid")]
+    IvalidScopes,
 }
 
 impl From<awc::error::HttpError> for OIDCValidationError {
@@ -80,6 +83,7 @@ impl ResponseError for OIDCValidationError {
             OIDCValidationError::ConnectivityError(_) => StatusCode::INTERNAL_SERVER_ERROR,
             OIDCValidationError::CryptoError(_) => StatusCode::INTERNAL_SERVER_ERROR,
             OIDCValidationError::IvalidAccess => StatusCode::FORBIDDEN,
+            OIDCValidationError::IvalidScopes=> StatusCode::FORBIDDEN,
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,7 +4,7 @@ Actix 4 JWT Auth is a OIDC based authentication mechanism.
 # Examples
 ```no_run
 use actix_4_jwt_auth::{
-    AuthenticatedUser, Oidc, OidcConfig, OidcBiscuitValidator, 
+    AuthenticatedUser, Oidc, OidcConfig, OidcBiscuitValidator, OidcScopeValidator,
     biscuit::{ValidationOptions, Validation}
 };
 use actix_web::{get, http::header, test, web, App, Error, HttpResponse, HttpServer};
@@ -38,9 +38,12 @@ async fn main() -> std::io::Result<()> {
         }
     };
 
+    let scope_validator = OidcScopeValidator(vec!["openid", "profile"]);
+    
     HttpServer::new(move || {
       App::new()
               .app_data(oidc.clone())
+              .wrap(scope_validator.clone())
               .wrap(biscuit_validator.clone())
               // .wrap(OidcBiscuitValidator::default()) //without issuer verification
               .service(authenticated_user)
@@ -68,12 +71,10 @@ mod oidc;
 
 #[doc(inline)]
 pub use ::biscuit;
-
 pub use extractor::{decoded_info::DecodedInfo, auth_user::AuthenticatedUser};
 pub use middleware::OidcBiscuitValidator;
 pub use oidc::{Oidc, OidcConfig};
 pub use error::OIDCValidationError;
-
 #[cfg(test)]
 mod tests {
     use actix_web::{test, http::header};


### PR DESCRIPTION
Added scope validation middleware

Such an access token validator helps to prevent users who do not have
the necessary scopes and clains for them